### PR TITLE
Remove zoom limts and opt for a toolbar instead

### DIFF
--- a/app/src/main/java/io/github/pastthepixels/freepaint/DrawCanvas.java
+++ b/app/src/main/java/io/github/pastthepixels/freepaint/DrawCanvas.java
@@ -210,6 +210,15 @@ public final class DrawCanvas extends View {
     }
 
     /**
+     * Gets the pan tool's offset
+     *
+     * @return The offset of the pan tool
+     */
+    public Point getPosition() {
+        return panTool.offset;
+    }
+
+    /**
      * Draws the document rectangle, paths, and then custom paths that tools create (ex. to show bounds of a selection)
      *
      * @param canvas the canvas on which the background will be drawn
@@ -217,6 +226,8 @@ public final class DrawCanvas extends View {
     protected void onDraw(Canvas canvas) {
         // Allows us to do things like setting a custom background
         super.onDraw(canvas);
+        //
+        ((MainActivity) getContext()).updateInfoBar();
         // Draws things on the screen
         canvas.save();
         // SCALES, THEN TRANSLATES (translations are independent of scales)

--- a/app/src/main/java/io/github/pastthepixels/freepaint/MainActivity.java
+++ b/app/src/main/java/io/github/pastthepixels/freepaint/MainActivity.java
@@ -271,6 +271,18 @@ public class MainActivity extends AppCompatActivity {
     }
 
     /**
+     * Updates the info bar with current scaling and position information.
+     */
+    @SuppressLint({"SetTextI18n", "DefaultLocale"})
+    public void updateInfoBar() {
+        binding.infoBar.setText(String.format("%.2fx, (%.1f, %.1f)",
+                binding.drawCanvas.getScaleFactor(),
+                binding.drawCanvas.getPosition().x,
+                binding.drawCanvas.getPosition().y
+        ));
+    }
+
+    /**
      * Updates the visibility of the FAB (ExpandToolbar) depending on its appropriate setting
      */
     public void updateFABVisibility() {

--- a/app/src/main/java/io/github/pastthepixels/freepaint/Tools/PanTool.java
+++ b/app/src/main/java/io/github/pastthepixels/freepaint/Tools/PanTool.java
@@ -14,11 +14,6 @@ import io.github.pastthepixels.freepaint.Point;
 
 public class PanTool implements Tool {
     /**
-     * Minimum (x) and maximum (y) scale factor
-     */
-    private final static Point SCALE_RESTRICTIONS = new Point(0.01f, 10f);
-
-    /**
      * Location of the last time an ACTION_DOWN touch was initialized (relative positions to that
      * are used for calculating new offsets)
      */
@@ -82,19 +77,11 @@ public class PanTool implements Tool {
             @Override
             public boolean onScale(@NonNull ScaleGestureDetector detector) {
                 scaleFactor *= detector.getScaleFactor();
-                updateScaleFactor();
                 updatePanOffset();
                 canvas.invalidate();
                 return true;
             }
         });
-    }
-
-    /**
-     * Clamps <code>scaleFactor</code> to minimum and maximum values (<code>SCALE_RESTRICTIONS</code>).
-     */
-    public void updateScaleFactor() {
-        scaleFactor = Math.max(SCALE_RESTRICTIONS.x, Math.min(scaleFactor, SCALE_RESTRICTIONS.y));
     }
 
     /**

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -41,11 +41,22 @@
         android:id="@+id/ExpandToolbar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom|start"
-        android:layout_marginStart="@dimen/fab_margin"
+        android:layout_gravity="bottom|end"
+        android:layout_marginEnd="@dimen/fab_margin"
         android:layout_marginBottom="16dp"
         android:contentDescription="@string/toggleToolbar"
         android:src="@drawable/baseline_arrow_drop_up_24"
         android:visibility="visible" />
+
+    <TextView
+        android:id="@+id/infoBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurface"
+        android:backgroundTint="#F2FFFFFF"
+        android:backgroundTintMode="multiply"
+        android:padding="10dp"
+        app:layout_anchor="@+id/drawCanvas"
+        app:layout_anchorGravity="bottom|center" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
If you're working with small documents, you might have noticed:
- It's hard to zoom in without reaching the limit
- FreePaint centers new documents; if the document is small enough, it might be impossible to center because the zoom limit is being reached.
In either case, working with small documents in FreePaint is difficult. However, there are legitimate reasons for having zoom limts, namely:
- It prevents users from zooming in/out too much and getting too confused
- If a user accidentally zooms in too much, they won't have any way of knowing.

A simpler fix that solves the issues created by zoom limits and _solved_ by zoom limits is to rather have an informative toolbar notifying users of the current scaling amount. It also serves to let users know when the document is scaled by 1x; that is, a line drawn with a width of 5 pixels appears as a line with a width of 5 _actual_ pixels.