### PR TITLE
Add switch to save preferences when the app exits

### DIFF
--- a/app/src/main/java/io/github/pastthepixels/freepaint/MainActivity.java
+++ b/app/src/main/java/io/github/pastthepixels/freepaint/MainActivity.java
@@ -2,6 +2,7 @@ package io.github.pastthepixels.freepaint;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
@@ -39,6 +40,7 @@ import com.rarepebble.colorpicker.ColorPreference;
 import com.takisoft.preferencex.PreferenceFragmentCompat;
 
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
 
 import io.github.pastthepixels.freepaint.databinding.ActivityMainBinding;
 
@@ -82,6 +84,14 @@ public class MainActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        // Resets settings if the setting is enabled to do that
+        if (!PreferenceManager.getDefaultSharedPreferences(this).getBoolean("savePrefsOnExit", true)) {
+            @SuppressLint("CommitPrefEdits") SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(this).edit();
+            editor.clear();
+            editor.putBoolean("savePrefsOnExit", false);
+            editor.commit();
+        }
 
         // Android things (including setting/adjusting layout)
         WindowCompat.setDecorFitsSystemWindows(getWindow(), false);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,4 +22,5 @@
     <!-- other -->
     <string name="draw_canvas_description">A canvas containing a rectangle, representing a document which users may draw on.</string>
     <string name="toggleToolbarToggle">Show a button to toggle the toolbar</string>
+    <string name="save_preferences_on_exit">Save preferences on exit</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -55,4 +55,10 @@
         app:title="@string/toggleToolbarToggle"
         app:widgetLayout="@layout/switch_preference_material" />
 
+    <SwitchPreference
+        android:defaultValue="true"
+        app:key="savePrefsOnExit"
+        app:title="@string/save_preferences_on_exit"
+        app:widgetLayout="@layout/switch_preference_material" />
+
 </PreferenceScreen>


### PR DESCRIPTION
This is actually not what's happening--preferences are reset when the app opens if this is set to false--but this is done because the app can always be killed before it has a chance to react and reset preferences.